### PR TITLE
feat: weather bot metrics → Telegram end-to-end (#3)

### DIFF
--- a/src/collectors/weather.py
+++ b/src/collectors/weather.py
@@ -119,8 +119,8 @@ class WeatherCollector(BaseCollector):
         if not os.path.isdir(state_dir):
             return 0.0, None, 0, []
 
-        # Only show active ColdMath A/B strategies
-        ACTIVE_STRATEGIES = {"coldmath_base", "coldmath_forecast"}
+        # Active strategies to report (updated from ColdMath to current latency strategies)
+        ACTIVE_STRATEGIES = {"metar_pure_latency", "synoptic_latency", "ensemble"}
         for path in sorted(glob.glob(os.path.join(state_dir, "*_state.json"))):
             try:
                 with open(path) as f:
@@ -138,15 +138,18 @@ class WeatherCollector(BaseCollector):
                 sharpe = state.get("sharpe", 0)
                 unrealized = state.get("unrealized_pnl", 0)
 
-                # Open positions — dict keyed by position ID
-                open_pos = state.get("open_positions", {})
-                n_open = len(open_pos)
+                # Open positions — dict keyed by position ID, or list of trade dicts
+                open_pos_raw = state.get("open_positions", state.get("open_trades", {}))
+                n_open = len(open_pos_raw)
                 total_open += n_open
 
-                # Closed positions — list of dicts
-                closed = state.get("closed_positions", [])
+                # Closed positions — list of dicts (supports "won" bool or "resolution" string)
+                closed = state.get("closed_positions", state.get("resolved_trades", []))
                 n_closed = len(closed)
-                wins = sum(1 for c in closed if c.get("won"))
+                wins = sum(
+                    1 for c in closed
+                    if c.get("won") or c.get("resolution") == "WIN"
+                )
                 wr = wins / n_closed if n_closed else None
 
                 total_pnl += pnl

--- a/src/status_engine.py
+++ b/src/status_engine.py
@@ -44,7 +44,7 @@ class StatusEngine:
 
         # Categorize by section
         weather = [m for m in sorted_metrics if m.collector_type == "trading_weather"]
-        crypto = [m for m in sorted_metrics if m.collector_type == "trading_crypto"]
+        crypto = [m for m in sorted_metrics if m.collector_type in ("trading_crypto", "trading_mm", "trading_decoded", "trading_momentum")]
         projects = [m for m in sorted_metrics if m.collector_type == "git"]
 
         now = datetime.utcnow()
@@ -55,8 +55,9 @@ class StatusEngine:
             lines.append("")
             lines.append("━━ WEATHER ━━")
             for m in weather:
+                lines.append(f"  {m.project_name.upper()}: {m.signals} signals, {m.trades} trades")
                 if m.error:
-                    lines.append(f"  ERROR: {m.error[:60]}")
+                    lines.append(f"    ERROR: {m.error[:60]}")
                     continue
                 for sub in m.sub_strategies:
                     lines.append(self._format_weather_sub(sub))
@@ -66,8 +67,9 @@ class StatusEngine:
             lines.append("")
             lines.append("━━ CRYPTO ━━")
             for m in crypto:
+                lines.append(f"  {m.project_name.upper()}: {m.fills} fills")
                 if m.error:
-                    lines.append(f"  ERROR: {m.error[:60]}")
+                    lines.append(f"    ERROR: {m.error[:60]}")
                     continue
                 # Sort sub-strategies by P&L descending
                 subs = sorted(m.sub_strategies, key=lambda s: s.get("pnl", 0), reverse=True)
@@ -78,10 +80,10 @@ class StatusEngine:
         if projects:
             lines.append("")
             lines.append("━━ PROJECTS ━━")
-            for m in projects:
+            for idx, m in enumerate(projects, start=1):
                 proj_alerts = alert_map.get(m.project_name, [])
                 status = self._determine_status(m, proj_alerts)
-                lines.append(self._format_git_project(m, status))
+                lines.append(self._format_git_project(m, status, idx))
 
         # Nag alerts
         nag_alerts = [a for a in alerts if a.days_stuck >= 2]
@@ -167,16 +169,17 @@ class StatusEngine:
             f"{sortino:.1f} Sort | {settled}/{n_open} | {runtime_str}"
         )
 
-    def _format_git_project(self, m: ProjectMetrics, status: str) -> str:
+    def _format_git_project(self, m: ProjectMetrics, status: str, idx: int = 0) -> str:
         """Format a git project line."""
         name = m.project_name
+        prefix = f"{idx}. " if idx else "  "
         if m.last_commit_date:
             days_ago = (datetime.utcnow() - m.last_commit_date.replace(tzinfo=None)).days
             msg = m.last_commit_message or ""
             if len(msg) > 40:
                 msg = msg[:37] + "..."
-            return f"  {name} {status} {days_ago}d ago — {msg}"
+            return f"  {prefix}{name} {status} {days_ago}d ago — {msg}"
         elif m.error:
-            return f"  {name} {status} {m.error[:50]}"
+            return f"  {prefix}{name} {status} {m.error[:50]}"
         else:
-            return f"  {name} {status} {m.status_text or 'No data'}"
+            return f"  {prefix}{name} {status} {m.status_text or 'No data'}"

--- a/tests/test_collectors.py
+++ b/tests/test_collectors.py
@@ -83,6 +83,39 @@ class TestWeatherCollector:
             assert m.open_positions == 2
             assert m.win_rate == pytest.approx(2 / 3)
 
+    def test_dead_strategies_filtered_out(self):
+        """Dead ColdMath strategies must not appear in portfolio state.
+
+        Strategy names 'coldmath_base' and 'coldmath_forecast' were retired.
+        The active set is metar_pure_latency, synoptic_latency, ensemble.
+        A state file for a dead strategy should contribute zero P&L.
+        """
+        from src.collectors.weather import WeatherCollector
+        with tempfile.TemporaryDirectory() as tmpdir:
+            state_dir = os.path.join(tmpdir, "weather_paper")
+            os.makedirs(state_dir)
+
+            dead_state = {
+                "strategy": "coldmath_base",
+                "portfolio": {"starting_balance": 1000, "balance": 2000},
+                "open_trades": [{"id": "x1"}],
+                "resolved_trades": [{"resolution": "WIN"}],
+            }
+            with open(os.path.join(state_dir, "coldmath_base_state.json"), "w") as f:
+                json.dump(dead_state, f)
+
+            import shutil
+            shutil.copy(os.path.join(FIXTURES, "signal_log.tsv"), tmpdir)
+            shutil.copy(os.path.join(FIXTURES, "paper_trades.tsv"), tmpdir)
+
+            config = self._make_config(tmpdir)
+            c = WeatherCollector(config)
+            m = c.collect()
+            # Dead strategy must not inflate P&L or position counts
+            assert m.pnl == 0.0
+            assert m.open_positions == 0
+            assert m.sub_strategies == []
+
 
 # ── Market Maker Collector ─────────────────────────────────────────
 

--- a/tests/test_collectors.py
+++ b/tests/test_collectors.py
@@ -255,3 +255,181 @@ class TestMomentumCollector:
         assert m.trades == 0
         assert m.pnl == 0.0
         assert m.healthy
+
+
+# ── Telegram Reporter ──────────────────────────────────────────────
+
+class TestTelegramReporter:
+
+    def test_send_skips_when_no_credentials(self):
+        """Reporter returns False and doesn't raise when no bot_token/chat_id."""
+        import os
+        from datetime import datetime
+        from src.telegram_reporter import TelegramReporter
+        from src.models import DailyReport
+
+        # Ensure env vars are not set
+        env_backup = {
+            "OPS_DASHBOARD_BOT_TOKEN": os.environ.pop("OPS_DASHBOARD_BOT_TOKEN", None),
+            "OPS_DASHBOARD_CHAT_ID": os.environ.pop("OPS_DASHBOARD_CHAT_ID", None),
+        }
+        try:
+            reporter = TelegramReporter(bot_token="", chat_id="")
+            report = DailyReport(
+                generated_at=datetime.utcnow(),
+                scorecard="Test scorecard",
+                project_metrics=[],
+                alerts=[],
+            )
+            result = reporter.send(report)
+            assert result is False
+        finally:
+            for k, v in env_backup.items():
+                if v is not None:
+                    os.environ[k] = v
+
+    def test_send_calls_telegram_api(self, monkeypatch):
+        """Reporter calls Telegram sendMessage endpoint with scorecard text."""
+        from datetime import datetime
+        import requests as req_module
+        from src.telegram_reporter import TelegramReporter
+        from src.models import DailyReport
+
+        calls = []
+
+        class MockResponse:
+            status_code = 200
+            def json(self):
+                return {"ok": True}
+
+        def mock_post(url, json=None, timeout=None):
+            calls.append({"url": url, "json": json})
+            return MockResponse()
+
+        monkeypatch.setattr(req_module, "post", mock_post)
+
+        reporter = TelegramReporter(bot_token="test_token", chat_id="12345")
+        report = DailyReport(
+            generated_at=datetime.utcnow(),
+            scorecard="Daily scorecard content",
+            project_metrics=[],
+            alerts=[],
+        )
+        result = reporter.send(report)
+
+        assert result is True
+        assert len(calls) == 1
+        assert "test_token" in calls[0]["url"]
+        assert "Daily scorecard content" in calls[0]["json"]["text"]
+        assert calls[0]["json"]["chat_id"] == "12345"
+
+    def test_send_falls_back_to_plain_text_on_parse_error(self, monkeypatch):
+        """Reporter falls back to plain text if Markdown fails (400 error)."""
+        from datetime import datetime
+        import requests as req_module
+        from src.telegram_reporter import TelegramReporter
+        from src.models import DailyReport
+
+        call_count = [0]
+
+        class MockResponse:
+            def __init__(self, status_code):
+                self.status_code = status_code
+                self.text = "Bad Request: can't parse entities"
+
+        def mock_post(url, json=None, timeout=None):
+            call_count[0] += 1
+            # First call (Markdown) fails; second (plain) succeeds
+            if call_count[0] == 1:
+                return MockResponse(400)
+            return MockResponse(200)
+
+        monkeypatch.setattr(req_module, "post", mock_post)
+
+        reporter = TelegramReporter(bot_token="tok", chat_id="99")
+        report = DailyReport(
+            generated_at=datetime.utcnow(),
+            scorecard="Plain fallback test",
+            project_metrics=[],
+            alerts=[],
+        )
+        result = reporter.send(report)
+
+        assert result is True
+        assert call_count[0] == 2  # Two attempts: Markdown then plain
+
+
+# ── End-to-End Pipeline ────────────────────────────────────────────
+
+class TestWeatherPipeline:
+    """End-to-end: WeatherCollector → StatusEngine → TelegramReporter (mocked)."""
+
+    def test_full_pipeline(self, monkeypatch, tmp_path):
+        """Full pipeline produces a scorecard and sends it via Telegram."""
+        import json
+        import shutil
+        import requests as req_module
+        from src.collectors.weather import WeatherCollector
+        from src.status_engine import StatusEngine
+        from src.telegram_reporter import TelegramReporter
+        from src.models import DailyReport
+
+        # Set up fixture files
+        state_dir = tmp_path / "weather_paper"
+        state_dir.mkdir()
+        state = {
+            "strategy": "metar_pure_latency",
+            "portfolio": {"starting_balance": 1000, "balance": 1100},
+            "open_trades": [],
+            "resolved_trades": [
+                {"resolution": "WIN"},
+                {"resolution": "WIN"},
+                {"resolution": "LOSS"},
+            ],
+        }
+        (state_dir / "metar_pure_latency_state.json").write_text(json.dumps(state))
+        shutil.copy(os.path.join(FIXTURES, "signal_log.tsv"), tmp_path)
+        shutil.copy(os.path.join(FIXTURES, "paper_trades.tsv"), tmp_path)
+
+        # Collect metrics
+        config = {
+            "name": "Weather Bot",
+            "collector_type": "trading_weather",
+            "base_path": str(tmp_path),
+            "paths": {
+                "signal_log": "signal_log.tsv",
+                "paper_trades": "paper_trades.tsv",
+                "portfolio_state_dir": "weather_paper",
+            },
+        }
+        collector = WeatherCollector(config)
+        metrics = collector.collect()
+
+        assert metrics.healthy
+        assert metrics.pnl == pytest.approx(100.0)
+        assert metrics.win_rate == pytest.approx(2 / 3)
+
+        # Generate scorecard
+        engine = StatusEngine()
+        report = engine.generate_report([metrics], [], ["Weather Bot"])
+        assert "WEATHER" in report.scorecard
+        assert len(report.scorecard) > 20
+
+        # Send via TelegramReporter (mocked)
+        sent_payloads = []
+
+        class MockResponse:
+            status_code = 200
+
+        def mock_post(url, json=None, timeout=None):
+            sent_payloads.append(json)
+            return MockResponse()
+
+        monkeypatch.setattr(req_module, "post", mock_post)
+
+        reporter = TelegramReporter(bot_token="pipeline_token", chat_id="777")
+        result = reporter.send(report)
+
+        assert result is True
+        assert len(sent_payloads) == 1
+        assert report.scorecard in sent_payloads[0]["text"]


### PR DESCRIPTION
## Summary

- End-to-end pipeline: WeatherCollector → StatusEngine → TelegramReporter — 21 tests passing
- Parses `signal_log.tsv`, `paper_trades.tsv`, and `data_cache/weather_paper/*_state.json`
- Active strategies confirmed as `metar_pure_latency`, `synoptic_latency`, `ensemble` (dead ColdMath strategies filtered out)
- Added `test_dead_strategies_filtered_out` to lock in the strategy filter behaviour

## Test plan

- [x] `python -m pytest tests/test_collectors.py -v -k "Weather"` — 5 tests pass
- [x] `python -m pytest tests/ -v` — all 21 tests pass

Closes #3

https://claude.ai/code/session_01APpEZbBwc4FGnnGiG61eAD