### PR TITLE
feat: /kill and /resume Telegram commands

### DIFF
--- a/src/kill_handler.py
+++ b/src/kill_handler.py
@@ -6,15 +6,25 @@ or resume-trading.sh. Manages confirmation state for /kill and /resume commands.
 
 import json
 import logging
+import os
 import subprocess
 from dataclasses import dataclass
 from typing import Optional
 
 logger = logging.getLogger(__name__)
 
-DUBLIN_HOST = "ubuntu@99.81.160.132"
-SSH_OPTS = ["-o", "ConnectTimeout=10", "-o", "StrictHostKeyChecking=no"]
+DUBLIN_HOST = os.environ.get("DUBLIN_SSH_HOST", "ubuntu@99.81.160.132")
+SSH_OPTS = ["-o", "ConnectTimeout=10", "-o", "StrictHostKeyChecking=accept-new"]
 VALID_TARGETS = {"crypto", "weather", "all"}
+
+ALLOWED_CHAT_IDS: set[str] = set(
+    filter(None, os.environ.get("OPS_DASHBOARD_CHAT_ID", "").split(","))
+)
+
+
+def is_authorized(chat_id: str) -> bool:
+    """Check if chat_id is in the allowlist for destructive commands."""
+    return chat_id in ALLOWED_CHAT_IDS
 
 
 @dataclass

--- a/src/kill_handler.py
+++ b/src/kill_handler.py
@@ -1,0 +1,149 @@
+"""Kill/resume handler for Telegram bot — SSHes to Dublin and runs VPS scripts.
+
+Uses subprocess to SSH into Dublin (99.81.160.132) and execute kill-trading.sh
+or resume-trading.sh. Manages confirmation state for /kill and /resume commands.
+"""
+
+import json
+import logging
+import subprocess
+from dataclasses import dataclass
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+DUBLIN_HOST = "ubuntu@99.81.160.132"
+SSH_OPTS = ["-o", "ConnectTimeout=10", "-o", "StrictHostKeyChecking=no"]
+VALID_TARGETS = {"crypto", "weather", "all"}
+
+
+@dataclass
+class PendingAction:
+    """A kill or resume awaiting YES confirmation."""
+    action: str  # "kill" or "resume"
+    target: str  # "crypto", "weather", "all"
+    info: str = ""  # resume context from --info
+
+
+# Per-chat pending confirmations: {chat_id: PendingAction}
+_pending: dict[str, PendingAction] = {}
+
+
+def _ssh_run(command: str) -> tuple[int, str]:
+    """Run a command on Dublin via SSH. Returns (returncode, stdout)."""
+    full_cmd = ["ssh"] + SSH_OPTS + [DUBLIN_HOST, command]
+    try:
+        result = subprocess.run(
+            full_cmd,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        return result.returncode, result.stdout.strip()
+    except subprocess.TimeoutExpired:
+        return 1, '{"error": "SSH timeout after 30s"}'
+    except Exception as e:
+        return 1, f'{{"error": "SSH failed: {e}"}}'
+
+
+def handle_kill(chat_id: str, text: str) -> str:
+    """Handle /kill <target> command. Returns response text."""
+    parts = text.strip().split()
+    if len(parts) < 2:
+        return "Usage: /kill crypto | weather | all"
+
+    target = parts[1].lower()
+    if target not in VALID_TARGETS:
+        return f"Unknown target '{target}'. Use: crypto, weather, or all"
+
+    # Store pending confirmation
+    _pending[chat_id] = PendingAction(action="kill", target=target)
+    return (
+        f"Kill {target} on Dublin?\n\n"
+        f"This will:\n"
+        f"- Stop the systemd service\n"
+        f"- Disable restart\n"
+        f"- Cancel all open CLOB orders\n\n"
+        f"Reply YES to confirm."
+    )
+
+
+def handle_resume(chat_id: str, text: str) -> str:
+    """Handle /resume <target> command. Returns response text."""
+    parts = text.strip().split()
+    if len(parts) < 2:
+        return "Usage: /resume crypto | weather | all"
+
+    target = parts[1].lower()
+    if target not in VALID_TARGETS:
+        return f"Unknown target '{target}'. Use: crypto, weather, or all"
+
+    # Get kill context first
+    rc, output = _ssh_run(f"bash ~/scripts/resume-trading.sh --info {target}")
+    if rc != 0:
+        return f"Cannot resume: {output}"
+
+    _pending[chat_id] = PendingAction(action="resume", target=target, info=output)
+
+    # Format the context for display
+    try:
+        info = json.loads(output)
+        context_lines = []
+        for key in ["crypto", "weather"]:
+            if key in info:
+                ctx = info[key]
+                context_lines.append(
+                    f"  {key}: killed at {ctx.get('killed_at', '?')} "
+                    f"by {ctx.get('source', '?')} — {ctx.get('reason', '?')}"
+                )
+        context = "\n".join(context_lines)
+    except (json.JSONDecodeError, KeyError):
+        context = output
+
+    return f"Resume {target} on Dublin?\n\n{context}\n\nReply YES to confirm."
+
+
+def handle_confirmation(chat_id: str, text: str) -> Optional[str]:
+    """Check if text is a YES confirmation for a pending action.
+
+    Returns response text if handled, None if no pending action for this chat.
+    """
+    if chat_id not in _pending:
+        return None
+
+    pending = _pending.pop(chat_id)
+
+    if text.strip().upper() != "YES":
+        return "Cancelled."
+
+    if pending.action == "kill":
+        rc, output = _ssh_run(
+            f"bash ~/scripts/kill-trading.sh {pending.target} telegram"
+        )
+        if rc == 0:
+            return f"KILL SWITCH ACTIVATED: {pending.target}\n\n{output}"
+        else:
+            return f"KILL SWITCH — PARTIAL FAILURE:\n\n{output}"
+
+    elif pending.action == "resume":
+        rc, output = _ssh_run(
+            f"bash ~/scripts/resume-trading.sh {pending.target}"
+        )
+        if rc == 0:
+            return f"RESUMED: {pending.target}\n\n{output}"
+        else:
+            return f"RESUME FAILED:\n\n{output}"
+
+    return None
+
+
+def handle_kill_status() -> str:
+    """Check kill switch status on Dublin. Returns formatted text."""
+    rc, output = _ssh_run(
+        'for f in /home/ubuntu/.kill-switch/*; do '
+        'if [ -f "$f" ]; then echo "$(basename "$f"): $(cat "$f")"; fi; '
+        'done; '
+        'if [ ! -d /home/ubuntu/.kill-switch ] || [ -z "$(ls /home/ubuntu/.kill-switch/ 2>/dev/null)" ]; then '
+        'echo "No active kill switches"; fi'
+    )
+    return f"Kill Switch Status:\n\n{output}"

--- a/src/telegram_reporter.py
+++ b/src/telegram_reporter.py
@@ -11,6 +11,12 @@ import threading
 
 import requests
 
+from src.kill_handler import (
+    handle_confirmation,
+    handle_kill,
+    handle_kill_status,
+    handle_resume,
+)
 from src.models import DailyReport
 
 logger = logging.getLogger(__name__)
@@ -91,13 +97,49 @@ class TelegramReporter:
                     text = msg.get("text", "")
                     chat_id = str(msg.get("chat", {}).get("id", ""))
 
-                    if text.startswith("/update") or text.startswith("/start"):
+                    if text.startswith("/kill"):
+                        logger.info(f"/kill from chat {chat_id}: {text}")
+                        self._send_message(chat_id, handle_kill(chat_id, text))
+
+                    elif text.startswith("/resume"):
+                        logger.info(f"/resume from chat {chat_id}: {text}")
+                        self._send_message(chat_id, handle_resume(chat_id, text))
+
+                    elif text.startswith("/status"):
+                        logger.info(f"/status from chat {chat_id}")
+                        try:
+                            report = report_fn()
+                            kill_status = handle_kill_status()
+                            self._send_message(
+                                chat_id,
+                                f"{report.scorecard}\n\n{kill_status}",
+                            )
+                        except Exception as e:
+                            self._send_message(chat_id, f"Error: {e}")
+
+                    elif text.startswith("/update") or text.startswith("/start"):
                         logger.info(f"/update from chat {chat_id}")
                         try:
                             report = report_fn()
                             self._send_message(chat_id, report.scorecard)
                         except Exception as e:
                             self._send_message(chat_id, f"Error generating report: {e}")
+
+                    elif text.startswith("/help"):
+                        self._send_message(chat_id, (
+                            "Commands:\n"
+                            "/update — Fresh status report\n"
+                            "/status — Status + kill switch state\n"
+                            "/kill crypto|weather|all — Hard kill\n"
+                            "/resume crypto|weather|all — Resume\n"
+                            "/help — This message"
+                        ))
+
+                    else:
+                        # Check for YES/NO confirmation of pending kill/resume
+                        reply = handle_confirmation(chat_id, text)
+                        if reply:
+                            self._send_message(chat_id, reply)
 
             except requests.exceptions.ReadTimeout:
                 continue  # normal for long-polling

--- a/src/telegram_reporter.py
+++ b/src/telegram_reporter.py
@@ -16,6 +16,7 @@ from src.kill_handler import (
     handle_kill,
     handle_kill_status,
     handle_resume,
+    is_authorized,
 )
 from src.models import DailyReport
 
@@ -59,10 +60,10 @@ class TelegramReporter:
             if resp.status_code == 200:
                 return True
 
-            logger.error(f"Telegram send failed: {resp.status_code} {resp.text[:200]}")
+            logger.error("Telegram send failed: %s %s", resp.status_code, resp.text[:200])
             return False
         except requests.RequestException as e:
-            logger.error(f"Telegram request failed: {e}")
+            logger.error("Telegram request failed: %s", e)
             return False
 
     def run_bot(self, report_fn):
@@ -87,7 +88,7 @@ class TelegramReporter:
                 }, timeout=35)
 
                 if resp.status_code != 200:
-                    logger.warning(f"getUpdates failed: {resp.status_code}")
+                    logger.warning("getUpdates failed: %s", resp.status_code)
                     continue
 
                 data = resp.json()
@@ -98,15 +99,21 @@ class TelegramReporter:
                     chat_id = str(msg.get("chat", {}).get("id", ""))
 
                     if text.startswith("/kill"):
-                        logger.info(f"/kill from chat {chat_id}: {text}")
+                        if not is_authorized(chat_id):
+                            self._send_message(chat_id, "Unauthorized.")
+                            continue
+                        logger.info("/kill from chat %s: %s", chat_id, text)
                         self._send_message(chat_id, handle_kill(chat_id, text))
 
                     elif text.startswith("/resume"):
-                        logger.info(f"/resume from chat {chat_id}: {text}")
+                        if not is_authorized(chat_id):
+                            self._send_message(chat_id, "Unauthorized.")
+                            continue
+                        logger.info("/resume from chat %s: %s", chat_id, text)
                         self._send_message(chat_id, handle_resume(chat_id, text))
 
                     elif text.startswith("/status"):
-                        logger.info(f"/status from chat {chat_id}")
+                        logger.info("/status from chat %s", chat_id)
                         try:
                             report = report_fn()
                             kill_status = handle_kill_status()
@@ -118,7 +125,7 @@ class TelegramReporter:
                             self._send_message(chat_id, f"Error: {e}")
 
                     elif text.startswith("/update") or text.startswith("/start"):
-                        logger.info(f"/update from chat {chat_id}")
+                        logger.info("/update from chat %s", chat_id)
                         try:
                             report = report_fn()
                             self._send_message(chat_id, report.scorecard)
@@ -144,6 +151,6 @@ class TelegramReporter:
             except requests.exceptions.ReadTimeout:
                 continue  # normal for long-polling
             except Exception as e:
-                logger.error(f"Bot loop error: {e}")
+                logger.error("Bot loop error: %s", e)
                 import time
                 time.sleep(5)

--- a/tests/test_kill_handler.py
+++ b/tests/test_kill_handler.py
@@ -1,0 +1,186 @@
+"""Tests for kill_handler — Telegram kill/resume confirmation state machine.
+
+Stubs _ssh_run at module level to avoid real SSH calls.
+Tests cover: validation, state machine, authorization.
+"""
+
+import src.kill_handler as kh
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _stub_ssh(returncode: int, stdout: str):
+    """Replace _ssh_run with a stub. Returns the original for restoration."""
+    original = kh._ssh_run
+    kh._ssh_run = lambda cmd: (returncode, stdout)
+    return original
+
+
+def _restore_ssh(original):
+    kh._ssh_run = original
+
+
+# ---------------------------------------------------------------------------
+# handle_kill
+# ---------------------------------------------------------------------------
+
+def test_handle_kill_missing_target():
+    result = kh.handle_kill("chat1", "/kill")
+    assert "Usage" in result
+
+
+def test_handle_kill_invalid_target():
+    result = kh.handle_kill("chat1", "/kill bitcoin")
+    assert "Unknown target" in result
+
+
+def test_handle_kill_valid_crypto():
+    kh._pending.clear()
+    result = kh.handle_kill("chat1", "/kill crypto")
+    assert "Kill crypto" in result
+    assert "YES" in result
+    assert "chat1" in kh._pending
+    assert kh._pending["chat1"].action == "kill"
+    assert kh._pending["chat1"].target == "crypto"
+    kh._pending.clear()
+
+
+def test_handle_kill_valid_all():
+    kh._pending.clear()
+    result = kh.handle_kill("chat1", "/kill all")
+    assert "Kill all" in result
+    assert kh._pending["chat1"].target == "all"
+    kh._pending.clear()
+
+
+# ---------------------------------------------------------------------------
+# handle_resume
+# ---------------------------------------------------------------------------
+
+def test_handle_resume_missing_target():
+    result = kh.handle_resume("chat2", "/resume")
+    assert "Usage" in result
+
+
+def test_handle_resume_invalid_target():
+    result = kh.handle_resume("chat2", "/resume litecoin")
+    assert "Unknown target" in result
+
+
+def test_handle_resume_valid_target():
+    kh._pending.clear()
+    orig = _stub_ssh(0, '{"crypto": {"killed_at": "2026-03-31", "source": "telegram", "reason": "test"}}')
+    try:
+        result = kh.handle_resume("chat2", "/resume crypto")
+        assert "Resume crypto" in result
+        assert "YES" in result
+        assert "chat2" in kh._pending
+        assert kh._pending["chat2"].action == "resume"
+    finally:
+        _restore_ssh(orig)
+        kh._pending.clear()
+
+
+def test_handle_resume_ssh_failure():
+    kh._pending.clear()
+    orig = _stub_ssh(1, '{"error": "no kill file"}')
+    try:
+        result = kh.handle_resume("chat2", "/resume crypto")
+        assert "Cannot resume" in result
+        assert "chat2" not in kh._pending
+    finally:
+        _restore_ssh(orig)
+
+
+# ---------------------------------------------------------------------------
+# handle_confirmation
+# ---------------------------------------------------------------------------
+
+def test_confirmation_no_pending():
+    kh._pending.clear()
+    result = kh.handle_confirmation("chat3", "YES")
+    assert result is None
+
+
+def test_confirmation_not_yes():
+    kh._pending.clear()
+    kh._pending["chat3"] = kh.PendingAction(action="kill", target="crypto")
+    result = kh.handle_confirmation("chat3", "no")
+    assert result == "Cancelled."
+    assert "chat3" not in kh._pending
+
+
+def test_confirmation_yes_kill_success():
+    kh._pending.clear()
+    kh._pending["chat3"] = kh.PendingAction(action="kill", target="crypto")
+    orig = _stub_ssh(0, "service stopped")
+    try:
+        result = kh.handle_confirmation("chat3", "YES")
+        assert "KILL SWITCH ACTIVATED" in result
+        assert "chat3" not in kh._pending
+    finally:
+        _restore_ssh(orig)
+
+
+def test_confirmation_yes_kill_failure():
+    kh._pending.clear()
+    kh._pending["chat3"] = kh.PendingAction(action="kill", target="weather")
+    orig = _stub_ssh(1, "partial error")
+    try:
+        result = kh.handle_confirmation("chat3", "YES")
+        assert "PARTIAL FAILURE" in result
+    finally:
+        _restore_ssh(orig)
+
+
+def test_confirmation_yes_resume_success():
+    kh._pending.clear()
+    kh._pending["chat3"] = kh.PendingAction(action="resume", target="crypto")
+    orig = _stub_ssh(0, "service started")
+    try:
+        result = kh.handle_confirmation("chat3", "YES")
+        assert "RESUMED" in result
+    finally:
+        _restore_ssh(orig)
+
+
+def test_confirmation_yes_resume_failure():
+    kh._pending.clear()
+    kh._pending["chat3"] = kh.PendingAction(action="resume", target="crypto")
+    orig = _stub_ssh(1, "resume error")
+    try:
+        result = kh.handle_confirmation("chat3", "YES")
+        assert "RESUME FAILED" in result
+    finally:
+        _restore_ssh(orig)
+
+
+# ---------------------------------------------------------------------------
+# handle_kill_status
+# ---------------------------------------------------------------------------
+
+def test_kill_status():
+    orig = _stub_ssh(0, "crypto: killed at 2026-03-31")
+    try:
+        result = kh.handle_kill_status()
+        assert "Kill Switch Status" in result
+        assert "crypto" in result
+    finally:
+        _restore_ssh(orig)
+
+
+# ---------------------------------------------------------------------------
+# is_authorized
+# ---------------------------------------------------------------------------
+
+def test_is_authorized_valid(monkeypatch):
+    monkeypatch.setattr(kh, "ALLOWED_CHAT_IDS", {"12345", "67890"})
+    assert kh.is_authorized("12345") is True
+    assert kh.is_authorized("99999") is False
+
+
+def test_is_authorized_empty(monkeypatch):
+    monkeypatch.setattr(kh, "ALLOWED_CHAT_IDS", set())
+    assert kh.is_authorized("12345") is False


### PR DESCRIPTION
## Summary

- Add `kill_handler.py`: SSH-based kill/resume with confirmation state machine
- Wire `/kill`, `/resume`, `/status`, `/help` commands into Telegram bot polling loop

## How it works

`/kill crypto` → bot asks "YES to confirm?" → on YES, SSHes to Dublin and runs `kill-trading.sh` → returns result. Same flow for `/resume`. `/status` appends kill switch state to the normal report.

## Test plan

- [x] Hetzner→Dublin SSH kill/resume path verified
- [x] Bot deployed and running on Hetzner
- [ ] Manual Telegram UI test: send `/kill crypto`, reply YES, verify response
